### PR TITLE
Testing PR vs non-PR GitHub actions with a simple PR

### DIFF
--- a/src/main/java/dvl4wa/VulnServlet.java
+++ b/src/main/java/dvl4wa/VulnServlet.java
@@ -17,11 +17,12 @@ public class VulnServlet extends HttpServlet {
       Map<String, String> headers = Collections.list(req.getHeaderNames()).stream().collect(Collectors.toMap(h -> h, req::getHeader));
       res.setContentType("text/plain; charset=utf-8");
       Writer writer = res.getWriter();
+	  // If there's an x-log header, we will send it to the log, unsanitized, triggering log4j exploit
       if(headers.containsKey("x-log")) {
         writer.write("Logging to console using vulnerable log4j2!\n");
         logger.info(headers.get("x-log"));
       } else {
-        writer.write("Hello world\n");
+        writer.write("Hello world!\n\nNo x-log header detected.\n");
       }
       writer.close();
     } catch(Exception e) {


### PR DESCRIPTION
Added comment for clarity and help text in case user fails to set x-log header before running app.